### PR TITLE
Include krb5_cc_copy_creds function

### DIFF
--- a/lib/Authen/Krb5.pm
+++ b/lib/Authen/Krb5.pm
@@ -114,6 +114,11 @@ error.
 Initializes a context for the application. Returns a C<Authen::Krb5::Context>
 object, or C<undef> if there was an error.
 
+=func C<cc_copy_creds(incc, outcc)>
+
+Copies a credential cache to a different one. C<outcc>, the credential cache
+to be filled in, can be of different type.
+
 =func C<init_ets() (DEPRECATED)>
 
 Initializes the Kerberos error tables.  Should be called along with

--- a/lib/Authen/Krb5.xs
+++ b/lib/Authen/Krb5.xs
@@ -617,6 +617,17 @@ krb5_recvauth(auth_context,fh,version,server,keytab)
 	sv_setref_pv(ST(0),"Authen::Krb5::Ticket",(void*)ticket);
 	XSRETURN(1);
 
+void
+cc_copy_creds(incc,outcc)
+        Authen::Krb5::Ccache incc
+        Authen::Krb5::Ccache outcc
+
+        CODE:
+        err = krb5_cc_copy_creds(context, incc, outcc);
+        if (err) XSRETURN_UNDEF;
+        XSRETURN_YES;
+
+
 
 MODULE = Authen::Krb5	PACKAGE = Authen::Krb5::Principal
 


### PR DESCRIPTION
We are porting some code that needs to generate FILE caches while working a new system that is configured with KCM.

Exposing this function would be handy in this situation to perform actions like:
```
use Authen::Krb5;

Authen::Krb5::init_context();

my $credCache = Authen::Krb5::cc_default();
my $newCreds = Authen::Krb5::cc_resolve("FILE:/tmp/legacy.cc");

$newCreds->initialize($credCache->get_principal());
Authen::Krb5::cc_copy_creds($credCache, $newCreds);
```